### PR TITLE
Ajuste en test E2E: máximo 4 lugares por usuario

### DIFF
--- a/app/templates/app/buy_ticket.html
+++ b/app/templates/app/buy_ticket.html
@@ -36,6 +36,7 @@
               </div>
             </div>
 
+            
             <div class="d-flex align-items-center mb-3">
               <div class="bg-light rounded-circle p-2 me-3">
                   <i class="bi bi-geo-alt text-primary"></i>
@@ -54,8 +55,10 @@
                   <p class="mb-0">{{ event.organizer }}</p>
               </div>
             </div>
+           
+            <p id="message-box"></p>
 
-            <form method="POST" action="{% url 'buy_ticket' event.id %}">
+            <form id="ticket-data-form" method="POST" action="{% url 'buy_ticket' event.id %}">
               {% csrf_token %}
 
               <div class="mb-3">
@@ -113,7 +116,7 @@
 
             <input type="hidden" id="discount" name="discount" value="">
 
-            {% if event.available_tickets > 0 %}
+            {% if event.available_tickets > 0 and available_tickets_to_buy > 0 %}
               <button type="submit" class="btn btn-primary w-100">Confirmar compra</button>
             {% else %}
               <button type="button" class="btn btn-secondary w-100" disabled>Entradas agotadas</button>
@@ -289,8 +292,6 @@
     const code = document.getElementById('discount-code').value;
     const totalElement = document.getElementById('total');
 
-    console.log('Código a enviar:',code);
-
     const totalPrice = parseFloat(totalElement.textContent);
 
     const discountMessage = document.getElementById('discount-message');
@@ -307,8 +308,6 @@
     .then(response => response.json())
 
     .then(data => {
-      console.log("DATA:", data)
-
       if (data.isValidCode) {
         const discountedPrice = totalPrice * data.multiplier;
         const finalPriceElement = document.getElementById('final-price')
@@ -380,6 +379,39 @@
       document.querySelector('#discounted-price').style.display = 'none';
     }
   }
+</script>
+
+<script>
+  document.getElementById('quantity').addEventListener('invalid', e => {
+    e.preventDefault();
+  
+    const quantityElement = document.getElementById('quantity');
+    const messageBoxElement = document.getElementById('message-box');
+
+    const quantity = parseInt(quantityElement.value);
+    const maxQuantity = parseInt(quantityElement.max);
+    const minQuantity = parseInt(quantityElement.min);
+
+    messageBoxElement.innerText = '';
+
+    if (quantity < minQuantity) {
+      messageBoxElement.innerText = '';
+      
+      messageBoxElement.classList.add('alert', 'alert-danger', 'mb-3');
+        
+      messageBoxElement.innerHTML = `<i class="bi bi-exclamation-triangle-fill me-2"></i> La cantidad no puede ser un valor negativo.`;
+          
+      
+    } else if (quantity > maxQuantity) {
+      messageBoxElement.innerText = '';
+      
+      messageBoxElement.classList.add('alert', 'alert-danger', 'mb-3');
+        
+      messageBoxElement.innerHTML = `<i class="bi bi-exclamation-triangle-fill me-2"></i> No puedes superar el límite de 4 entradas por usario. Puedes comprar ${maxQuantity}.`;
+    }
+
+
+  });
 </script>
 
   <!-- CUSTOM STYLES -->

--- a/app/test/test_e2e/base.py
+++ b/app/test/test_e2e/base.py
@@ -90,4 +90,16 @@ class BaseE2ETest(StaticLiveServerTestCase):
         
         # Verificar que estamos en la página de eventos
         self.page.wait_for_url(re.compile(r".*/events/?.*"), timeout=20000)
+    
+    def complete_card_data_in_buy_ticket_form(self):
+        """
+        Método auxiliar para completar el campo de las tarjetas de crédito dentro de la compra de un ticket.
+        
+        - Se deberá acceder a la página de compra del ticket antes de utilizar este método.
+        """
+        self.page.fill("#card_number", "1234567890123456")
+        self.page.fill("#expiry", "12/30")
+        self.page.fill("#cvv", "123")
+        self.page.fill("#card_name", "Usuario Test")
+        self.page.check("#terms")
 

--- a/app/test/test_e2e/test_overselling_e2e.py
+++ b/app/test/test_e2e/test_overselling_e2e.py
@@ -74,7 +74,7 @@ class OversellingPreventionTest(BaseE2ETest):
         self.page.wait_for_selector("#quantity")
         self.page.fill("#quantity", "2")
         self.page.get_by_label("Tipo de entrada").select_option("GENERAL")
-        self.completar_formulario_pago()
+        self.complete_card_data_in_buy_ticket_form()
         self.page.get_by_role("button", name="Confirmar compra").click()
         self.page.wait_for_load_state("networkidle")
         with transaction.atomic():

--- a/app/test/test_e2e/test_overselling_e2e.py
+++ b/app/test/test_e2e/test_overselling_e2e.py
@@ -64,13 +64,6 @@ class OversellingPreventionTest(BaseE2ETest):
             event=self.event,
             user=self.normie_user
         )
-
-    def completar_formulario_pago(self):
-        self.page.fill("#card_number", "1234567890123456")
-        self.page.fill("#expiry", "12/30")
-        self.page.fill("#cvv", "123")
-        self.page.fill("#card_name", "Usuario Test")
-        self.page.check("#terms")
     
     def test_cannot_exceed_remaining_capacity(self):
         """Test que verifica que no se pueden comprar más tickets que los disponibles después de compras previas"""
@@ -94,7 +87,7 @@ class OversellingPreventionTest(BaseE2ETest):
         self.page.wait_for_selector("#quantity")
         self.page.fill("#quantity", "2")
         self.page.get_by_label("Tipo de entrada").select_option("GENERAL")
-        self.completar_formulario_pago()
+        self.complete_card_data_in_buy_ticket_form()
         self.page.get_by_role("button", name="Confirmar compra").click()
 
 #        error_message = self.page.get_by_text("No hay suficientes entradas disponibles. Solo quedan 2 entradas.")


### PR DESCRIPTION
# AJUSTE DEL TEST E2E DE TICKET: MÁXIMO 4 LUGARES POR USUARIO
Se modificó la validación del test E2E para verificar que no se puedan seleccionar más de 4 lugares por usuario. Anteriormente, la validación se basaba en presionar el botón de incremento hasta alcanzar el límite. Ahora se prueba ingresando manualmente un valor inválido (mayor a 4), lo que:
- Impide el envío del formulario.
- Muestra un mensaje de error.
- El test verifica que el mensaje sea el esperado.

## Cambios incluidos:
- Un nuevo método para rellenar el campo de la tarjeta de crédito en el formulario de compra en el archivo `base.py`.
- Se incluyo el uso del método anterior en el test `test_overselling_e2e.py` para mejorar la consistencia y evitar errores.
- Un nuevo script y elemento `<p>` en el template `buy_ticket.html` para manejar los mensajes de error y su aspecto.
- Se eliminaron lineas comentadas en desuso.