### PR TITLE
Crear un script para la Integración Continua

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        
+    - name: Build
+      run: |
+        python manage.py check
+        python manage.py collectstatic --noinput

--- a/eventhub/settings.py
+++ b/eventhub/settings.py
@@ -106,6 +106,8 @@ STATIC_URL = "/static/"
 # Bootstrap 5
 STATICFILES_DIRS = [BASE_DIR / "static"]
 
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/
 
@@ -123,6 +125,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
 STATIC_URL = "static/"
+
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field


### PR DESCRIPTION
# CREACIÓN DE UN SCRIPT PARA LA INTEGRACIÓN CONTINUA
**Funcionalidad:** Se integra mediante `GitHub Actions`, un job para realizar integración continua al realizar un  `pull request` o un `push`  hacia la rama `main`.

## Para la funcionalidad se realizó:
- Creación de un script para la integracion continua en: `.github/workflows/ci.yml`.
- Agregación del job encargado del build el cual instala las dependencias y verifica que no haya errores de configuracion.
- Agregación de una ruta estática en el archivo `eventhub/settings.py`.