### PR TITLE
Habilitar Deploy Continuo al hacer merge en main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,17 +1,15 @@
 name: CD
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.event == 'release' && github.event.workflow_run.conclusion == 'success' }}
-
+    
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
Este PR actualiza el workflow de CD para permitir el despliegue automático cada vez que se hace merge de un pull request a la rama main.

- El workflow ahora se ejecuta en cada push a main.
- Ya no es necesario crear un release manual para desplegar.
- El proceso de despliegue sigue igual: se construye la imagen Docker, se sube a Docker Hub y se dispara el hook de Render.

Con este cambio, cada modificación que se integre en main será desplegada automáticamente.